### PR TITLE
Activity feed prototype

### DIFF
--- a/src/main/java/codeu/controller/ActivityFeedServlet.java
+++ b/src/main/java/codeu/controller/ActivityFeedServlet.java
@@ -1,0 +1,39 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ActivityFeedServlet extends HttpServlet {
+
+  @Override
+  public void init() throws ServletException {
+    super.init();
+  }
+
+  /**
+   * This function fires when a user navigates to the Activity Feed page.
+   * It simply forwards the request to the corresponding jsp view
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    request.getRequestDispatcher("/WEB-INF/view/activityFeed.jsp").forward(request, response);
+  }
+}

--- a/src/main/webapp/WEB-INF/tags/base.tag
+++ b/src/main/webapp/WEB-INF/tags/base.tag
@@ -25,6 +25,7 @@
   <nav>
     <a id="navTitle" href="/">&lt;EastCode/&gt;</a>
     <a href="/conversations">Conversations</a>
+    <a href="/activity">Activity Feed</a>
     <% if(request.getSession().getAttribute("user") != null){ %>
       <a>Hello <%= request.getSession().getAttribute("user") %>!</a>
     <% } else{ %>

--- a/src/main/webapp/WEB-INF/tags/base.tag
+++ b/src/main/webapp/WEB-INF/tags/base.tag
@@ -1,0 +1,43 @@
+<%@tag description="Main base template for chat app"%>
+<%--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>EastCode Chat</title>
+  <link rel="stylesheet" href="/css/main.css">
+</head>
+<body>
+
+  <nav>
+    <a id="navTitle" href="/">&lt;EastCode/&gt;</a>
+    <a href="/conversations">Conversations</a>
+    <% if(request.getSession().getAttribute("user") != null){ %>
+      <a>Hello <%= request.getSession().getAttribute("user") %>!</a>
+    <% } else{ %>
+      <a href="/login">Login</a>
+    <% } %>
+    <a href="/about.jsp">About</a>
+  </nav>
+
+  <div id="container">
+    <div
+      style="width:75%; margin-left:auto; margin-right:auto; margin-top: 50px;">
+        <jsp:doBody/>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/view/activityFeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityFeed.jsp
@@ -1,0 +1,21 @@
+<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<%--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+    <t:base>
+      <h1>Activity Feed</h1>
+  </t:base>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -66,4 +66,14 @@
     <url-pattern>/register</url-pattern>
   </servlet-mapping>
 
+  <servlet>
+    <servlet-name>ActivityFeedServlet</servlet-name>
+    <servlet-class>codeu.controller.ActivityFeedServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>ActivityFeedServlet</servlet-name>
+    <url-pattern>/activity</url-pattern>
+  </servlet-mapping>
+
 </web-app>

--- a/src/test/java/codeu/controller/ActivityFeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityFeedServletTest.java
@@ -1,0 +1,52 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ActivityFeedServletTest {
+
+    private ActivityFeedServlet activityFeedServlet;
+    private HttpServletRequest mockRequest;
+    private HttpServletResponse mockResponse;
+    private RequestDispatcher mockRequestDispatcher;
+
+    @Before
+    public void setup() {
+        activityFeedServlet = new ActivityFeedServlet();
+
+        mockRequest = Mockito.mock(HttpServletRequest.class);
+        mockResponse = Mockito.mock(HttpServletResponse.class);
+
+        mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
+        Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/activityFeed.jsp"))
+                .thenReturn(mockRequestDispatcher);
+    }
+
+    @Test
+    public void testDoGet() throws IOException, ServletException {
+        activityFeedServlet.doGet(mockRequest, mockResponse);
+        //verify request dispatcher's forward method is called with the mockRequest and mockResponse
+        Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    }
+}


### PR DESCRIPTION
* Added base template 
    * Added the tags folder, which will hold JSP tags and templates for the web app.
    * Added the base tag file, which would serve as the main template for the app.

* Added activityFeed.jsp with a basic header, and using the base template

* Added ActivityFeedServlet with a basic `doGet` method that forwards to the corresponding JSP. The routing has been added to `web.xml`

* Added unit test for ActivityFeedServlet