### PR TITLE
EastBot prototype

### DIFF
--- a/src/main/java/codeu/controller/BotServlet.java
+++ b/src/main/java/codeu/controller/BotServlet.java
@@ -1,0 +1,148 @@
+package codeu.controller;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.Message;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.MessageStore;
+import codeu.model.store.basic.UserStore;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public class BotServlet extends HttpServlet {
+
+    private ConversationStore conversationStore;
+    private MessageStore messageStore;
+    private UserStore userStore;
+
+    /**
+     * Sets the {@link ConversationStore} used by this servlet. This function provides a common setup method
+     * for use by the test framework or the servlet's init() function.
+     */
+    void setConversationStore(ConversationStore conversationStore) {
+        this.conversationStore = conversationStore;
+    }
+
+    /**
+     * Sets the {@link MessageStore} used by this servlet. This function provides a common setup method
+     * for use by the test framework or the servlet's init() function.
+     */
+    void setMessageStore(MessageStore messageStore) {
+        this.messageStore = messageStore;
+    }
+
+    /**
+     * Sets the {@link UserStore} used by this servlet. This function provides a common setup method
+     * for use by the test framework or the servlet's init() function.
+     */
+    void setUserStore(UserStore userStore) {
+        this.userStore = userStore;
+    }
+
+    /**
+     * Set up state for handling chat requests.
+     */
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        setConversationStore(ConversationStore.getInstance());
+        setMessageStore(MessageStore.getInstance());
+        setUserStore(UserStore.getInstance());
+    }
+
+    /**
+     * This function fires when a user navigates to the chatbot page. It gets the username from the session
+     * and loads the corresponding chatbot conversation for the user, if the user is logged in, and forwards the
+     * messages in the conversation to chat.jsp
+     */
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        String user = (String) request.getSession().getAttribute("user");
+
+        if (user == null) {
+            response.sendRedirect("/login");
+            return;
+        }
+
+        final String conversationTitle = "chatbot-" + user.hashCode();
+
+        Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
+        if (conversation == null) {
+            System.out.println("BotServlet-doGet: Chatbot conversation was null for user `" + user + "`: " + conversationTitle);
+            response.sendRedirect("/conversations");
+            return;
+        }
+
+        UUID conversationId = conversation.getId();
+
+        List<Message> messages = messageStore.getMessagesInConversation(conversationId);
+
+        request.setAttribute("conversation", conversation);
+        request.setAttribute("messages", messages);
+        request.setAttribute("messagePostUrl", "/bot");
+        request.setAttribute("customChatTitle", "EastBot");
+        request.getRequestDispatcher("/WEB-INF/view/chat.jsp").forward(request, response);
+    }
+
+    /**
+     * This function fires when a user submits the form on the chatbot page. It gets the logged-in
+     * username from the session, the chat message from the submitted form data.
+     * It creates a new Message from that data, adds it to the model, and then
+     * redirects back to the chatbot page.
+     */
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+
+        String username = (String) request.getSession().getAttribute("user");
+        if (username == null) {
+            // user is not logged in, don't let them add a message
+            response.sendRedirect("/login");
+            return;
+        }
+
+        final String conversationTitle = "chatbot-" + username.hashCode();
+
+        Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
+        if (conversation == null) {
+            System.out.println("BotServlet-doPost: Chatbot conversation was null for user `" + username + "`: " + conversationTitle);
+            response.sendRedirect("/conversations");
+            return;
+        }
+
+        User user = userStore.getUser(username);
+        if (user == null) {
+            System.out.println("BotServlet-doPost: No user with username `" + username + "`");
+            response.sendRedirect("/login");
+            return;
+        }
+
+
+        String messageContent = request.getParameter("message");
+
+        // this removes any HTML from the message content
+        String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
+
+        Message message =
+                new Message(
+                        UUID.randomUUID(),
+                        conversation.getId(),
+                        user.getId(),
+                        cleanedMessageContent,
+                        Instant.now());
+
+        messageStore.addMessage(message);
+
+        // redirect to a GET request
+        response.sendRedirect("/bot");
+    }
+}

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -118,6 +118,7 @@ public class ChatServlet extends HttpServlet {
 
     request.setAttribute("conversation", conversation);
     request.setAttribute("messages", messages);
+      request.setAttribute("messagePostUrl", "/chat/" + conversationTitle);
     request.getRequestDispatcher("/WEB-INF/view/chat.jsp").forward(request, response);
   }
 

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -87,7 +87,7 @@ public class ConversationServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
-    List<Conversation> conversations = conversationStore.getAllConversations();
+    List<Conversation> conversations = conversationStore.getAllPublicConversations();
     request.setAttribute("conversations", conversations);
     request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
   }

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -25,8 +25,8 @@ public class Conversation {
   public final UUID id;
   public final UUID owner;
   public final Instant creation;
-    public String title;
-    private boolean isPrivate;
+  public final String title;
+  private boolean isPrivate;
 
   /**
    * Constructs a new Conversation.
@@ -41,7 +41,7 @@ public class Conversation {
     this.owner = owner;
     this.creation = creation;
     this.title = title;
-      this.isPrivate = false;
+    this.isPrivate = false;
   }
 
   /** Returns the ID of this Conversation. */
@@ -59,20 +59,16 @@ public class Conversation {
     return title;
   }
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
   /** Returns the creation time of this Conversation. */
   public Instant getCreationTime() {
     return creation;
   }
 
-    public boolean isPrivate() {
-        return isPrivate;
-    }
+  public boolean isPrivate() {
+    return isPrivate;
+  }
 
-    public void setPrivate(boolean isPrivate) {
-        this.isPrivate = isPrivate;
-    }
+  public void setPrivate(boolean isPrivate) {
+    this.isPrivate = isPrivate;
+  }
 }

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -25,7 +25,8 @@ public class Conversation {
   public final UUID id;
   public final UUID owner;
   public final Instant creation;
-  public final String title;
+    public String title;
+    private boolean isPrivate;
 
   /**
    * Constructs a new Conversation.
@@ -40,6 +41,7 @@ public class Conversation {
     this.owner = owner;
     this.creation = creation;
     this.title = title;
+      this.isPrivate = false;
   }
 
   /** Returns the ID of this Conversation. */
@@ -57,8 +59,20 @@ public class Conversation {
     return title;
   }
 
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
   /** Returns the creation time of this Conversation. */
   public Instant getCreationTime() {
     return creation;
   }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public void setPrivate(boolean isPrivate) {
+        this.isPrivate = isPrivate;
+    }
 }

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -18,6 +18,7 @@ import codeu.model.data.Conversation;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Store class that uses in-memory data structures to hold values and automatically loads from and
@@ -69,6 +70,12 @@ public class ConversationStore {
     return conversations;
   }
 
+    /**
+     * Gets all public conversations known to the application
+     */
+    public List<Conversation> getAllPublicConversations() {
+        return conversations.stream().filter(conversation -> !conversation.isPrivate()).collect(Collectors.toList());
+    }
 
   /** Add a new conversation to the current set of conversations known to the application. */
   public void addConversation(Conversation conversation) {

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -108,7 +108,9 @@ public class PersistentDataStore {
         UUID ownerUuid = UUID.fromString((String) entity.getProperty("owner_uuid"));
         String title = (String) entity.getProperty("title");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
+          boolean isPrivate = (boolean) entity.getProperty("is_private");
         Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime);
+          conversation.setPrivate(isPrivate);
         conversations.add(conversation);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -221,6 +223,7 @@ public class PersistentDataStore {
     conversationEntity.setProperty("owner_uuid", conversation.getOwnerId().toString());
     conversationEntity.setProperty("title", conversation.getTitle());
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
+      conversationEntity.setProperty("is_private", conversation.isPrivate());
     datastore.put(conversationEntity);
   }
 

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -40,7 +40,7 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
           </script>
     </jsp:attribute>
     <jsp:attribute name="bodyContent">
-            <h1><%= conversation.getTitle() %>
+            <h1><%= request.getAttribute("customChatTitle") != null ? request.getAttribute("customChatTitle") : conversation.getTitle() %>
               <a href="" style="float: right">&#8635;</a></h1>
 
             <hr/>
@@ -62,7 +62,7 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
             <hr/>
 
             <% if (request.getSession().getAttribute("user") != null) { %>
-            <form action="/chat/<%= conversation.getTitle() %>" method="POST">
+            <form action='<%= (String)request.getAttribute("messagePostUrl") %>' method="POST">
                 <input type="text" name="message">
                 <br/>
                 <button type="submit">Send</button>

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -40,6 +40,10 @@
 
         <h1>Conversations</h1>
 
+        <ul class="mdl-list">
+            <li><a href="/bot">EastBot</a></li>
+        </ul>
+
         <%
         List<Conversation> conversations =
           (List<Conversation>) request.getAttribute("conversations");

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -97,5 +97,15 @@
     <url-pattern>/profile</url-pattern>
   </servlet-mapping>
 
+    <servlet>
+        <servlet-name>BotServlet</servlet-name>
+        <servlet-class>codeu.controller.BotServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>BotServlet</servlet-name>
+        <url-pattern>/bot</url-pattern>
+    </servlet-mapping>
+
 
 </web-app>

--- a/src/test/java/codeu/controller/BotServletTest.java
+++ b/src/test/java/codeu/controller/BotServletTest.java
@@ -1,0 +1,189 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.Message;
+import codeu.model.data.User;
+import codeu.model.store.basic.ActivityStore;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.MessageStore;
+import codeu.model.store.basic.UserStore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class BotServletTest {
+
+    private BotServlet botServlet;
+    private HttpServletRequest mockRequest;
+    private HttpSession mockSession;
+    private HttpServletResponse mockResponse;
+    private RequestDispatcher mockRequestDispatcher;
+    private ConversationStore mockConversationStore;
+    private MessageStore mockMessageStore;
+    private UserStore mockUserStore;
+    private ActivityStore mockActivityStore;
+
+    @Before
+    public void setup() {
+        botServlet = new BotServlet();
+
+        mockRequest = Mockito.mock(HttpServletRequest.class);
+        mockSession = Mockito.mock(HttpSession.class);
+        Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
+
+        mockResponse = Mockito.mock(HttpServletResponse.class);
+        mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
+        Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/chat.jsp"))
+                .thenReturn(mockRequestDispatcher);
+
+        mockConversationStore = Mockito.mock(ConversationStore.class);
+        botServlet.setConversationStore(mockConversationStore);
+
+        mockMessageStore = Mockito.mock(MessageStore.class);
+        botServlet.setMessageStore(mockMessageStore);
+
+        mockUserStore = Mockito.mock(UserStore.class);
+        botServlet.setUserStore(mockUserStore);
+    }
+
+    @Test
+    public void testDoGet() throws IOException, ServletException {
+        String username = "mock_user";
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(username);
+
+        UUID fakeConversationId = UUID.randomUUID();
+        Conversation fakeConversation =
+                new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+
+        Mockito.when(mockConversationStore.getConversationWithTitle("chatbot-" + username.hashCode()))
+                .thenReturn(fakeConversation);
+
+        List<Message> fakeMessageList = new ArrayList<>();
+        fakeMessageList.add(
+                new Message(
+                        UUID.randomUUID(),
+                        fakeConversationId,
+                        UUID.randomUUID(),
+                        "test message",
+                        Instant.now())
+        );
+
+        Mockito.when(mockMessageStore.getMessagesInConversation(fakeConversationId))
+                .thenReturn(fakeMessageList);
+
+        botServlet.doGet(mockRequest, mockResponse);
+
+        Mockito.verify(mockRequest).setAttribute("conversation", fakeConversation);
+        Mockito.verify(mockRequest).setAttribute("messages", fakeMessageList);
+        Mockito.verify(mockRequest).setAttribute("messagePostUrl", "/bot");
+        Mockito.verify(mockRequest).setAttribute("customChatTitle", "EastBot");
+        Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testDoGet_NotLoggedInUser() throws IOException, ServletException {
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
+
+        botServlet.doGet(mockRequest, mockResponse);
+        Mockito.verify(mockResponse).sendRedirect("/login");
+    }
+
+    @Test
+    public void testDoGet_BadConversation() throws IOException, ServletException {
+        String username = "mock_user";
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(username);
+
+        Mockito.when(mockConversationStore.getConversationWithTitle(Mockito.anyString())).thenReturn(null);
+
+        botServlet.doGet(mockRequest, mockResponse);
+        Mockito.verify(mockResponse).sendRedirect("/conversations");
+    }
+
+    @Test
+    public void testDoPost() throws IOException, ServletException {
+        String username = "mock_user";
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(username);
+
+        UUID fakeConversationId = UUID.randomUUID();
+        Conversation fakeConversation =
+                new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+
+        Mockito.when(mockConversationStore.getConversationWithTitle("chatbot-" + username.hashCode()))
+                .thenReturn(fakeConversation);
+
+        User fakeUser = new User(UUID.randomUUID(), username, "@@#!#!@@@", Instant.now(), false);
+        Mockito.when(mockUserStore.getUser(username)).thenReturn(fakeUser);
+
+        Mockito.when(mockRequest.getParameter("message")).thenReturn("mock_message");
+
+        botServlet.doPost(mockRequest, mockResponse);
+
+        ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+        Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
+        Assert.assertEquals("mock_message", messageArgumentCaptor.getValue().getContent());
+    }
+
+    @Test
+    public void testDoPost_NotLoggedInUser() throws IOException, ServletException {
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
+
+        botServlet.doPost(mockRequest, mockResponse);
+
+        Mockito.verify(mockResponse).sendRedirect("/login");
+    }
+
+    @Test
+    public void testDoPost_BadConversation() throws IOException, ServletException {
+        String username = "mock_user";
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(username);
+        Mockito.when(mockConversationStore.getConversationWithTitle(Mockito.anyString())).thenReturn(null);
+
+        botServlet.doPost(mockRequest, mockResponse);
+
+        Mockito.verify(mockResponse).sendRedirect("/conversations");
+    }
+
+    @Test
+    public void testDoPost_BadUsername() throws IOException, ServletException {
+        String username = "mock_user";
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(username);
+
+        Conversation fakeConversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        Mockito.when(mockConversationStore.getConversationWithTitle(Mockito.anyString())).thenReturn(fakeConversation);
+
+        Mockito.when(mockUserStore.getUser(username)).thenReturn(null);
+
+        botServlet.doPost(mockRequest, mockResponse);
+
+        Mockito.verify(mockResponse).sendRedirect("/login");
+    }
+
+
+}

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -102,6 +102,7 @@ public class ChatServletTest {
 
     Mockito.verify(mockRequest).setAttribute("conversation", fakeConversation);
     Mockito.verify(mockRequest).setAttribute("messages", fakeMessageList);
+    Mockito.verify(mockRequest).setAttribute("messagePostUrl", "/chat/test_conversation");
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -76,7 +76,7 @@ public class ConversationServletTest {
     List<Conversation> fakeConversationList = new ArrayList<>();
     fakeConversationList.add(
         new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now()));
-    Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
+      Mockito.when(mockConversationStore.getAllPublicConversations()).thenReturn(fakeConversationList);
 
     conversationServlet.doGet(mockRequest, mockResponse);
 

--- a/src/test/java/codeu/controller/RegisterServletTest.java
+++ b/src/test/java/codeu/controller/RegisterServletTest.java
@@ -9,7 +9,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import codeu.enumeration.ActivityTypeEnum;
 import codeu.model.data.Activity;
+import codeu.model.data.Conversation;
 import codeu.model.store.basic.ActivityStore;
+import codeu.model.store.basic.ConversationStore;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -67,7 +69,10 @@ public class RegisterServletTest {
 
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(false);
+
+    ConversationStore mockConversationStore = Mockito.mock(ConversationStore.class);
     registerServlet.setUserStore(mockUserStore);
+    registerServlet.setConversationStore(mockConversationStore);
 
     registerServlet.doPost(mockRequest, mockResponse);
 
@@ -80,6 +85,13 @@ public class RegisterServletTest {
     Assert.assertEquals(60, userArgumentCaptor.getValue().getPasswordHash().length());
     Assert.assertEquals(false, userArgumentCaptor.getValue().getAdmin());
 
+    //Chatbot conversation
+    ArgumentCaptor<Conversation> conversationArgumentCaptor = ArgumentCaptor.forClass(Conversation.class);
+    Mockito.verify(mockConversationStore).addConversation(conversationArgumentCaptor.capture());
+    Assert.assertEquals("chatbot-" + "test username".hashCode(), conversationArgumentCaptor.getValue().getTitle());
+    Assert.assertEquals(userArgumentCaptor.getValue().getId(), conversationArgumentCaptor.getValue().getOwnerId());
+    Assert.assertTrue(conversationArgumentCaptor.getValue().isPrivate());
+
     Mockito.verify(mockResponse).sendRedirect("/login");
   }
 
@@ -90,7 +102,11 @@ public class RegisterServletTest {
 
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("admin")).thenReturn(false);
+
+    ConversationStore mockConversationStore = Mockito.mock(ConversationStore.class);
+
     registerServlet.setUserStore(mockUserStore);
+    registerServlet.setConversationStore(mockConversationStore);
 
     registerServlet.doPost(mockRequest, mockResponse);
 
@@ -100,6 +116,8 @@ public class RegisterServletTest {
     Assert.assertEquals("admin", userArgumentCaptor.getValue().getName());
     Assert.assertEquals(true, userArgumentCaptor.getValue().getAdmin());
 
+    Mockito.verify(mockConversationStore).addConversation(Mockito.any(Conversation.class));
+
     Mockito.verify(mockResponse).sendRedirect("/login");
   }
   @Test
@@ -108,7 +126,11 @@ public class RegisterServletTest {
 
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(true);
+
+    ConversationStore mockConversationStore = Mockito.mock(ConversationStore.class);
+
     registerServlet.setUserStore(mockUserStore);
+    registerServlet.setConversationStore(mockConversationStore);
 
     registerServlet.doPost(mockRequest, mockResponse);
 
@@ -124,7 +146,11 @@ public class RegisterServletTest {
 
         UserStore mockUserStore = Mockito.mock(UserStore.class);
         Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(false);
+
+      ConversationStore mockConversationStore = Mockito.mock(ConversationStore.class);
+
         registerServlet.setUserStore(mockUserStore);
+      registerServlet.setConversationStore(mockConversationStore);
 
         registerServlet.doPost(mockRequest, mockResponse);
 

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -23,16 +23,43 @@ public class ConversationTest {
 
   @Test
   public void testCreate() {
-    UUID id = UUID.randomUUID();
-    UUID owner = UUID.randomUUID();
-    String title = "Test_Title";
-    Instant creation = Instant.now();
+      UUID id = UUID.randomUUID();
+      UUID owner = UUID.randomUUID();
+      String title = "Test_Title";
+      Instant creation = Instant.now();
 
-    Conversation conversation = new Conversation(id, owner, title, creation);
+      Conversation conversation = new Conversation(id, owner, title, creation);
 
-    Assert.assertEquals(id, conversation.getId());
-    Assert.assertEquals(owner, conversation.getOwnerId());
-    Assert.assertEquals(title, conversation.getTitle());
-    Assert.assertEquals(creation, conversation.getCreationTime());
+      Assert.assertEquals(id, conversation.getId());
+      Assert.assertEquals(owner, conversation.getOwnerId());
+      Assert.assertEquals(title, conversation.getTitle());
+      Assert.assertEquals(creation, conversation.getCreationTime());
+      Assert.assertFalse(conversation.isPrivate());
   }
+
+    @Test
+    public void test_setTitle() {
+        UUID id = UUID.randomUUID();
+        UUID owner = UUID.randomUUID();
+        String title = "Test_Title";
+        Instant creation = Instant.now();
+
+        Conversation conversation = new Conversation(id, owner, title, creation);
+        conversation.setTitle("set_test_title");
+
+        Assert.assertEquals("set_test_title", conversation.getTitle());
+    }
+
+    @Test
+    public void test_set_private() {
+        UUID id = UUID.randomUUID();
+        UUID owner = UUID.randomUUID();
+        String title = "Test_Title";
+        Instant creation = Instant.now();
+
+        Conversation conversation = new Conversation(id, owner, title, creation);
+        conversation.setPrivate(true);
+
+        Assert.assertTrue(conversation.isPrivate());
+    }
 }

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -38,19 +38,6 @@ public class ConversationTest {
   }
 
     @Test
-    public void test_setTitle() {
-        UUID id = UUID.randomUUID();
-        UUID owner = UUID.randomUUID();
-        String title = "Test_Title";
-        Instant creation = Instant.now();
-
-        Conversation conversation = new Conversation(id, owner, title, creation);
-        conversation.setTitle("set_test_title");
-
-        Assert.assertEquals("set_test_title", conversation.getTitle());
-    }
-
-    @Test
     public void test_set_private() {
         UUID id = UUID.randomUUID();
         UUID owner = UUID.randomUUID();

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -20,6 +20,10 @@ public class ConversationStoreTest {
       new Conversation(
           UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000));
 
+  private final Conversation CONVERSATION_TWO =
+          new Conversation(
+                  UUID.randomUUID(), UUID.randomUUID(), "conversation_two", Instant.ofEpochMilli(1000));
+
   @Before
   public void setup() {
     mockPersistentStorageAgent = Mockito.mock(PersistentStorageAgent.class);
@@ -27,6 +31,8 @@ public class ConversationStoreTest {
 
     final List<Conversation> conversationList = new ArrayList<>();
     conversationList.add(CONVERSATION_ONE);
+    CONVERSATION_TWO.setPrivate(true);
+    conversationList.add(CONVERSATION_TWO);
     conversationStore.setConversations(conversationList);
   }
 
@@ -43,6 +49,13 @@ public class ConversationStoreTest {
     Conversation resultConversation = conversationStore.getConversationWithTitle("unfound_title");
 
     Assert.assertNull(resultConversation);
+  }
+
+  @Test
+  public void testGetAllPublicConversations() {
+    List<Conversation> publicConversations = conversationStore.getAllPublicConversations();
+    Assert.assertEquals(1, publicConversations.size());
+    Assert.assertEquals(CONVERSATION_ONE, publicConversations.get(0));
   }
 
   @Test

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -90,6 +90,7 @@ public class PersistentDataStoreTest {
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
     Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo);
+      inputConversationTwo.setPrivate(true);
 
     // save
     persistentDataStore.writeThrough(inputConversationOne);
@@ -104,12 +105,14 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(ownerOne, resultConversationOne.getOwnerId());
     Assert.assertEquals(titleOne, resultConversationOne.getTitle());
     Assert.assertEquals(creationOne, resultConversationOne.getCreationTime());
+      Assert.assertFalse(resultConversationOne.isPrivate());
 
     Conversation resultConversationTwo = resultConversations.get(1);
     Assert.assertEquals(idTwo, resultConversationTwo.getId());
     Assert.assertEquals(ownerTwo, resultConversationTwo.getOwnerId());
     Assert.assertEquals(titleTwo, resultConversationTwo.getTitle());
     Assert.assertEquals(creationTwo, resultConversationTwo.getCreationTime());
+      Assert.assertTrue(resultConversationTwo.isPrivate());
   }
 
   @Test


### PR DESCRIPTION
This PR takes care of setting up the chat bot page, which is essentially a special conversation private to each user. These conversations are generated upon registration of the user, and are visible only to their respective user.

### Changes

---
* Updates to Conversations model: Added the `isPrivate` property

* Updated the PersistentDataStore to persist the new `isPrivate` field on the Conversation model

* Added `getAllPublicConversations` to the conversation store to make it possible to prevent private conversations, such as the chatbot ones, from being displayed on the conversations page

* Updated the `chat.jsp` and the `ChatServlet` to allow for custom `POST` urls on message submission during a conversation

* Updated the ConversationServlet to only show public conversations, and updated the jsp to add a link to the bot page

* Added the BotServlet and its route which will take care of rendering the bot conversation page, and receiving messages to it.

* Updated the RegisterServlet so that a private conversation for every user is created upon registration of that user

---

![screenshot from 2018-06-10 09-18-42](https://user-images.githubusercontent.com/20066988/41201275-5a30a648-6c8f-11e8-8e69-7913b2151bcd.png)
![screenshot from 2018-06-10 09-19-02](https://user-images.githubusercontent.com/20066988/41201276-5a470078-6c8f-11e8-91ee-1c6dbd285009.png)