### PR TITLE
EastBot: Sending Messages to Conversations

### DIFF
--- a/src/main/java/codeu/controller/BotServlet.java
+++ b/src/main/java/codeu/controller/BotServlet.java
@@ -156,7 +156,7 @@ public class BotServlet extends HttpServlet {
 
         String responseMessageContent;
         try{
-            responseMessageContent = botService.process(cleanedMessageContent);
+            responseMessageContent = botService.process(cleanedMessageContent, user);
         }
         catch(IOException | HttpException ex){
             responseMessageContent = "Oh, it seems we could not reach EastBot right now! Please try again soon, or let an admin"+

--- a/src/main/java/codeu/service/ChatService.java
+++ b/src/main/java/codeu/service/ChatService.java
@@ -1,0 +1,58 @@
+package codeu.service;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.Message;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.MessageStore;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class ChatService {
+
+    private ConversationStore conversationStore;
+    private MessageStore messageStore;
+
+    /**
+     * Sets the ConversationStore used by this servlet. This function provides a common setup method
+     * for use by the test framework or the service's constructor
+     */
+    void setConversationStore(ConversationStore conversationStore) {
+        this.conversationStore = conversationStore;
+    }
+
+    /**
+     * Sets the MessageStore used by this servlet. This function provides a common setup method for
+     * use by the test framework or the servlet's init() function.
+     */
+    void setMessageStore(MessageStore messageStore) {
+        this.messageStore = messageStore;
+    }
+
+    public ChatService(){
+        setConversationStore(ConversationStore.getInstance());
+        setMessageStore(MessageStore.getInstance());
+    }
+
+    /**
+     * Sends a message to the indicated conversation, with the provided body and author
+     *
+     * @param author The author of the message
+     * @param messageBody The body of the message to add to the conversation
+     * @param conversationName The title of the conversation to send the message to
+     * @throws IllegalArgumentException If the provided conversationName could not be found in the store
+     */
+    public void sendMessageToConversation(User author, String messageBody, String conversationName) throws IllegalArgumentException{
+        Conversation conversation = conversationStore.getConversationWithTitle(conversationName);
+        if(conversation == null){
+            String errorMessage = "ChatService-sendMessageToConversation:" +
+                    " Conversation with name "+conversationName+" could not be found";
+            System.out.println(errorMessage);
+            throw new IllegalArgumentException(errorMessage);
+        }
+
+        Message message = new Message(UUID.randomUUID(), conversation.getId(), author.getId(), messageBody, Instant.now());
+        messageStore.addMessage(message);
+    }
+}

--- a/src/test/java/codeu/controller/BotServletTest.java
+++ b/src/test/java/codeu/controller/BotServletTest.java
@@ -152,7 +152,7 @@ public class BotServletTest {
         Mockito.when(mockUserStore.getUser(username)).thenReturn(fakeUser);
 
         Mockito.when(mockRequest.getParameter("message")).thenReturn("mock_message");
-        Mockito.when(mockBotService.process("mock_message")).thenReturn("mock bot response");
+        Mockito.when(mockBotService.process("mock_message", fakeUser)).thenReturn("mock bot response");
         Mockito.when(mockUserStore.getUser("EastBot")).thenReturn(chatBot);
 
         botServlet.doPost(mockRequest, mockResponse);

--- a/src/test/java/codeu/service/BotServiceTest.java
+++ b/src/test/java/codeu/service/BotServiceTest.java
@@ -1,5 +1,6 @@
 package codeu.service;
 
+import codeu.model.data.User;
 import com.google.api.client.json.JsonObjectParser;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
@@ -21,11 +22,15 @@ public class BotServiceTest {
 
     private CloseableHttpClient httpClient;
     private CloseableHttpResponse httpResponse;
+    private User issuer;
+    private ChatService chatService;
 
     @Before
     public void setup(){
         httpClient = Mockito.mock(CloseableHttpClient.class);
         httpResponse = Mockito.mock(CloseableHttpResponse.class);
+        chatService = Mockito.mock(ChatService.class);
+        issuer = Mockito.mock(User.class);
     }
 
     @Test
@@ -45,26 +50,94 @@ public class BotServiceTest {
         queryResult.put("speech", "test speech response");
         responseBody.put("result", queryResult);
 
-        BotService botService = new BotService(httpClient, parser);
+        BotService botService = new BotService(httpClient, parser, chatService);
 
         Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponse);
         Mockito.when(httpResponse.getEntity()).thenReturn(entity);
         Mockito.when(entity.getContent()).thenReturn(contentStream);
         Mockito.when(parser.parseAndClose(contentStream, StandardCharsets.UTF_8, HashMap.class)).thenReturn(responseBody);
 
-        String actualResponse = botService.process("What's the time in New York?");
+        String actualResponse = botService.process("What's the time in New York?", issuer);
         Assert.assertEquals("test speech response", actualResponse);
+    }
+
+    @Test
+    public void testProcess_sendMessageAction() throws IOException, HttpException{
+        HttpEntity entity = Mockito.mock(HttpEntity.class);
+        JsonObjectParser parser = Mockito.mock(JsonObjectParser.class);
+        InputStream contentStream = Mockito.mock(InputStream.class);
+
+        HashMap responseBody = new HashMap();
+        HashMap responseStatus = new HashMap();
+        HashMap queryResult = new HashMap();
+        HashMap parameters = new HashMap();
+
+        responseStatus.put("code", new BigDecimal(200));
+        responseBody.put("status", responseStatus);
+
+        parameters.put("message", "test message");
+        parameters.put("conversation", "test_conversation");
+
+        queryResult.put("action", "send_message");
+        queryResult.put("speech", "test speech response");
+        queryResult.put("parameters", parameters);
+        responseBody.put("result", queryResult);
+
+        BotService botService = new BotService(httpClient, parser, chatService);
+
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponse);
+        Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+        Mockito.when(entity.getContent()).thenReturn(contentStream);
+        Mockito.when(parser.parseAndClose(contentStream, StandardCharsets.UTF_8, HashMap.class)).thenReturn(responseBody);
+
+        String actualResponse = botService.process("Send, test message, to test_conversation", issuer);
+        Mockito.verify(chatService).sendMessageToConversation(issuer, "test message", "test_conversation");
+        Assert.assertEquals("test speech response", actualResponse);
+    }
+
+    @Test
+    public void testProcess_sendMessageAction_onNonexistentConversation() throws IOException, HttpException{
+        HttpEntity entity = Mockito.mock(HttpEntity.class);
+        JsonObjectParser parser = Mockito.mock(JsonObjectParser.class);
+        InputStream contentStream = Mockito.mock(InputStream.class);
+
+        HashMap responseBody = new HashMap();
+        HashMap responseStatus = new HashMap();
+        HashMap queryResult = new HashMap();
+        HashMap parameters = new HashMap();
+
+        responseStatus.put("code", new BigDecimal(200));
+        responseBody.put("status", responseStatus);
+
+        parameters.put("message", "test message");
+        parameters.put("conversation", "test_conversation");
+
+        queryResult.put("action", "send_message");
+        queryResult.put("speech", "test speech response");
+        queryResult.put("parameters", parameters);
+        responseBody.put("result", queryResult);
+
+        BotService botService = new BotService(httpClient, parser, chatService);
+
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponse);
+        Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+        Mockito.when(entity.getContent()).thenReturn(contentStream);
+        Mockito.when(parser.parseAndClose(contentStream, StandardCharsets.UTF_8, HashMap.class)).thenReturn(responseBody);
+        Mockito.doThrow(new IllegalArgumentException()).when(chatService).sendMessageToConversation(issuer, "test message", "test_conversation");
+
+        String actualResponse = botService.process("Send, test message, to test_conversation", issuer);
+        Assert.assertEquals("Oh, I am sorry, it seems like that conversation does not exist yet!", actualResponse);
     }
 
     @Test(expected = IOException.class)
     public void testProcess_andClientThrowsIOException_andExpectIOException() throws IOException, HttpException{
         JsonObjectParser parser = Mockito.mock(JsonObjectParser.class);
 
-        BotService botService = new BotService(httpClient, parser);
+        BotService botService = new BotService(httpClient, parser, chatService);
 
         Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenThrow(new IOException());
 
-        botService.process("What's the time in New York?");
+        botService.process("What's the time in New York?", issuer);
     }
 
     @Test(expected = HttpException.class)
@@ -79,13 +152,13 @@ public class BotServiceTest {
         responseStatus.put("code", new BigDecimal(400)); //400 Bad Request
         responseBody.put("status", responseStatus);
 
-        BotService botService = new BotService(httpClient, parser);
+        BotService botService = new BotService(httpClient, parser, chatService);
 
         Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(httpResponse);
         Mockito.when(httpResponse.getEntity()).thenReturn(entity);
         Mockito.when(entity.getContent()).thenReturn(contentStream);
         Mockito.when(parser.parseAndClose(contentStream, StandardCharsets.UTF_8, HashMap.class)).thenReturn(responseBody);
 
-        botService.process("What's the time in New York?");
+        botService.process("What's the time in New York?", issuer);
     }
 }

--- a/src/test/java/codeu/service/ChatServiceTest.java
+++ b/src/test/java/codeu/service/ChatServiceTest.java
@@ -1,0 +1,64 @@
+package codeu.service;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.Message;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.MessageStore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+public class ChatServiceTest {
+
+    private ConversationStore conversationStore;
+    private MessageStore messageStore;
+    private ChatService chatService;
+
+    @Before
+    public void setup(){
+        conversationStore = Mockito.mock(ConversationStore.class);
+        messageStore = Mockito.mock(MessageStore.class);
+        chatService = new ChatService();
+        chatService.setConversationStore(conversationStore);
+        chatService.setMessageStore(messageStore);
+    }
+
+    @Test
+    public void testSendMessageToConversation() throws IllegalArgumentException {
+        String conversationName = "test_conversation";
+        String messageBody = "test message";
+        Conversation conversation = Mockito.mock(Conversation.class);
+        UUID conversationId = UUID.randomUUID();
+        User author = Mockito.mock(User.class);
+        UUID authorId = UUID.randomUUID();
+
+        Mockito.when(conversationStore.getConversationWithTitle(conversationName)).thenReturn(conversation);
+        Mockito.when(author.getId()).thenReturn(authorId);
+        Mockito.when(conversation.getId()).thenReturn(conversationId);
+
+        chatService.sendMessageToConversation(author, messageBody, conversationName);
+        ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+        Mockito.verify(messageStore).addMessage(messageArgumentCaptor.capture());
+        Assert.assertEquals(messageBody, messageArgumentCaptor.getValue().getContent());
+        Assert.assertEquals(conversationId, messageArgumentCaptor.getValue().getConversationId());
+        Assert.assertEquals(authorId, messageArgumentCaptor.getValue().getAuthorId());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSendMessageToConversation_withNonExistentConversation_andExpectIllegalArgumentException()
+            throws IllegalArgumentException
+    {
+        String conversationName = "test_conversation";
+        String messageBody = "test message";
+        User author = Mockito.mock(User.class);
+
+        Mockito.when(conversationStore.getConversationWithTitle(conversationName)).thenReturn(null);
+
+        chatService.sendMessageToConversation(author, messageBody, conversationName);
+    }
+}


### PR DESCRIPTION
This PR takes care of actioning on the user message to EastBot if the query matches the intent to send a message to a conversation. EastBot will attempt to send the message to the indicated conversation on behalf of the user, and will notify the user with the status of the action (success/failure)

* Changes:

    1) Added the ChatService, which will take care of handling chat related actions. For now, it handles sending a message to a conversation

    2) Used the ChatService in the BotService

    3) Made the BotService's `process` method require an `issuer` parameter, which will be the User issuing the query request

![eastbot](https://user-images.githubusercontent.com/20066988/42421647-7550b85c-82b3-11e8-87a4-a945853b5fce.png)
